### PR TITLE
Fix compilation with MSVC

### DIFF
--- a/src/animation.h
+++ b/src/animation.h
@@ -4,7 +4,7 @@
 #include <QString>
 #include <QMap>
 
-struct Animation
+class Animation
 {
 public:
     Animation();

--- a/src/dataType.h
+++ b/src/dataType.h
@@ -2,6 +2,7 @@
 #define DATATYPE_H
 
 #include <qglobal.h>
+#include <stdint.h>
 
 class UVector
 {

--- a/src/messages.cpp
+++ b/src/messages.cpp
@@ -8,7 +8,7 @@
 #include "log.h"
 #include "scene.h"
 
-#define DEBUG_LOG false
+#define DEBUG_LOG 0
 
 // File-global game-entering mutex (to prevent multiple instantiates)
 static QMutex levelLoadMutex;

--- a/src/packetloss.h
+++ b/src/packetloss.h
@@ -2,8 +2,8 @@
 #define PACKETLOSS_H
 
 // DO *NOT* USE the following options unless for debugging. Drops UDP packets at random.
-#define UDP_SIMULATE_PACKETLOSS false
-#define UDP_LOG_PACKETLOSS false
+#define UDP_SIMULATE_PACKETLOSS 0
+#define UDP_LOG_PACKETLOSS 0
 #define UDP_SEND_PERCENT_DROPPED 30
 #define UDP_RECV_PERCENT_DROPPED 30
 

--- a/src/player.cpp
+++ b/src/player.cpp
@@ -15,7 +15,7 @@
 #include "settings.h"
 #endif
 
-#define DEBUG_LOG false
+#define DEBUG_LOG 0
 
 QList<Player*> Player::tcpPlayers; // Used by the TCP login server
 QList<Player*> Player::udpPlayers; // Used by the UDP game server

--- a/src/receiveMessage.cpp
+++ b/src/receiveMessage.cpp
@@ -13,7 +13,7 @@
 #include "log.h"
 #include "settings.h"
 
-#define DEBUG_LOG false
+#define DEBUG_LOG 0
 
 void receiveMessage(Player* player)
 {

--- a/src/tcp.cpp
+++ b/src/tcp.cpp
@@ -5,7 +5,7 @@
 #include "settings.h"
 #include <QCryptographicHash>
 
-#define DEBUG_LOG false
+#define DEBUG_LOG 0
 
 using namespace Settings;
 


### PR DESCRIPTION
Fix compile errors when building with MSVC compiler.

- Typedefs like uint16_t, uint32_t, ... were not defined.
- Got error "Invalid integer constant expression" when comparing
  macros. To fix, I changed the values from false to 0.
- A forwarded class definition was mistakenly forward declared as
  struct

I would like to add that the program won't work when compiled with MSVC. QObject-connecting always crashes.